### PR TITLE
fix(vercel-config): Quickfix for Client vercel.json

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,11 +4,5 @@
             "src": "/[^.]+",
             "dest": "/"
         }
-    ],
-    "rewrites": [
-        {
-            "source": "/(.*)",
-            "destination": "/"
-        }
     ]
 }


### PR DESCRIPTION
## Changes
1. Removed rewrites option from vercel.json.

## Purpose
To remove rewrites option from vercel.json since routes is already in use in the file.