### PR TITLE
refactor(article-comments): Added New Settings and Protections to ArticleComment logic

### DIFF
--- a/client/src/hooks/useArticle.ts
+++ b/client/src/hooks/useArticle.ts
@@ -80,7 +80,7 @@ function useArticle(articleUID: string | undefined, limit: number) {
         
         console.log(response.data.comments)
         setArticleObj((article)=>(
-            article?{...article,  comments:response.data.comments, ipCanComment:false}:article
+            article?{...article,  comments:response.data.comments, ipCanComment:user?true:false}:article
         ))
     }
 

--- a/client/src/hooks/useArticle.ts
+++ b/client/src/hooks/useArticle.ts
@@ -80,7 +80,7 @@ function useArticle(articleUID: string | undefined, limit: number) {
         
         console.log(response.data.comments)
         setArticleObj((article)=>(
-            article?{...article,  comments:response.data.comments}:article
+            article?{...article,  comments:response.data.comments, ipCanComment:false}:article
         ))
     }
 

--- a/client/src/pages/ArticlePage/NewCommentField.tsx
+++ b/client/src/pages/ArticlePage/NewCommentField.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import './NewCommentField.css'
 
-export default function NewCommentField(props:{postComment: (comment:string)=>Promise<void>}) {
+export default function NewCommentField(props:{postComment: (comment:string)=>Promise<void>, disabled?:boolean}) {
     const [comment, setComment] = useState<string>("")
 
     function onSubmit(e: React.FormEvent) {
@@ -18,11 +18,17 @@ export default function NewCommentField(props:{postComment: (comment:string)=>Pr
         <textarea
             onChange={(e)=>setComment(e.target.value)}
             value={comment}
-            placeholder="Share your thoughts..."
+            placeholder={props.disabled?"Sign in to leave a comment.":"Share your thoughts..."}
             className="comment-form-text"
+            disabled={props.disabled}
         >
         </textarea>
-        {comment?<input type="submit" value="Post" className="submit-button"/>:<></>}
+        {comment?<input
+            type="submit"
+            value="Post"
+            className="submit-button"
+            disabled={props.disabled}
+        />:<></>}
     </form>
     )
 }

--- a/client/src/pages/ArticlePage/index.tsx
+++ b/client/src/pages/ArticlePage/index.tsx
@@ -12,12 +12,14 @@ import NewCommentField from './NewCommentField';
 
 import './index.css'
 import { useArticle } from '../../hooks/useArticle';
+import { useUserContext } from '../../contexts/UserContext';
 
 const RECOMMENDED_ARTICLES_COUNT: number = 8
 
 const ArticlePage: React.FC = () => {
     const { articleUID } = useParams()
     const {articleObj, recommendedArticles, postComment} = useArticle(articleUID, RECOMMENDED_ARTICLES_COUNT)
+    const {user} =  useUserContext()
 
     const defaultMainArticleImage: ArticleImage = {
         ...defaultArticleImage,
@@ -44,7 +46,18 @@ const ArticlePage: React.FC = () => {
         recommendedArticles.map((article)=><ArticleThumbnail key={article._id?.toString()} article={article}/>)
     )
 
-    
+    let comment_disabled = false
+    if (articleObj.allowComments === false) {
+        comment_disabled = true
+    }
+    else if (articleObj.allowAnonymousComments === false && user === null) {
+        comment_disabled = true
+    }
+    else if (articleObj.ipCanComment == false && user === null) {
+        comment_disabled = true
+    }
+    console.log(articleObj.ipCanComment)
+
 
     return (
     <main className='article-container'>
@@ -59,8 +72,10 @@ const ArticlePage: React.FC = () => {
             <img className="article--img" src={mainImage.url} />
             <h5 className='image--caption'>{mainImage.caption}</h5>
             {body}
-            <NewCommentField postComment={postComment}/>
-            <ArticleCommentList comments={articleObj.comments} />
+            {articleObj.allowComments==false?<></>:<>
+                <NewCommentField postComment={postComment} disabled={comment_disabled}/>
+                <ArticleCommentList comments={articleObj.comments} />
+            </>}
         </div>
         <div className='more-news'>
             <h2 className="home--more-news">MORE NEWS: {articleObj?.tags[0].toUpperCase()} </h2>

--- a/client/src/types/interfaces/Article.ts
+++ b/client/src/types/interfaces/Article.ts
@@ -28,6 +28,7 @@ interface Article {
     allowComments?: boolean
     allowAnonymousComments?: boolean
     comments?: ArticleComment[]
+    ipCanComment?: boolean
 }
 
 export type { Article }

--- a/server/models/Article.ts
+++ b/server/models/Article.ts
@@ -190,9 +190,13 @@ async function createComment(articleId: string, newComment: ArticleComment) {
 
     if (!existingArticle) {
         console.error(`Article with ID ${articleId} not found.`)
-        return;
-      }
-  
+        throw Error(`Article not found.`)
+    }
+
+    if (existingArticle.allowComments === false) {
+        throw Error(`Comments not allowed`)
+    }
+
     if (!existingArticle.comments) {
         existingArticle.comments = []
     }
@@ -200,6 +204,11 @@ async function createComment(articleId: string, newComment: ArticleComment) {
     if (newComment.userName === "anonymous" && existingArticle.comments.find((comment)=>(comment.ip==newComment.ip))) {
         console.error(`Article with ID ${articleId} not found.`)
         throw Error(`Ip already posted on this article.`)
+    }
+    
+    if (newComment.userName === "anonymous" && existingArticle.allowAnonymousComments === false) {
+        console.error(`Anonymous comments not allowed on ${articleId}.`)
+        throw Error(`Anonymous comments are disabled.`)
     }
 
     const commentWithId = {

--- a/server/routes/articleRoute.ts
+++ b/server/routes/articleRoute.ts
@@ -32,6 +32,9 @@ router.get('/:uid', async (req, res) => {
     if (article == null) {
         return res.status(500).json({ message: 'Article Not Found' })
     }
+    if (article.comments?.find((comment)=>comment.ip==req.ip && comment.userName=="anonymous")) {
+        article.ipCanComment = false
+    }
     if (article.comments) {
         article.comments = [...cleanComments(article.comments)]
     }

--- a/server/types/interfaces/Article.ts
+++ b/server/types/interfaces/Article.ts
@@ -21,6 +21,7 @@ interface Article {
     allowComments?: boolean,
     allowAnonymousComments?: boolean,
     comments?: ArticleComment[]
+    ipCanComment?: boolean
 }
 
 export type { Article }


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added ipCanComment field to articles returned by API
2. Added backed protection to enforce comment settings
3. Added frontend logic to accurately reflect backend protections

## Purpose
_Describe the problem or feature._
Comment settings were not being enforced

## Approach
_How does this change address the problem?_
The backend returns error when a comment would break rules, and front end prevents normal user from seeing those error by making the front end UI reflect those rules.

## Learning
_Describe the research stage_
N/A

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #87 